### PR TITLE
Rename Primer default palette as `mark17`

### DIFF
--- a/R/discrete-primer.R
+++ b/R/discrete-primer.R
@@ -3,7 +3,7 @@
 #' The Primer design system data visualization palette.
 #'
 #' @param palette Palette type.
-#'   Currently there is one available option: `"default"`
+#'   Currently there is one available option: `"mark17"`
 #'   (17-color palette).
 #' @param alpha Transparency level, a real number in (0, 1].
 #'   See `alpha` in [grDevices::rgb()] for details.
@@ -21,9 +21,9 @@
 #'
 #' @examples
 #' library("scales")
-#' show_col(pal_primer("default")(17))
-#' show_col(pal_primer("default", alpha = 0.6)(17))
-pal_primer <- function(palette = c("default"), alpha = 1) {
+#' show_col(pal_primer("mark17")(17))
+#' show_col(pal_primer("mark17", alpha = 0.6)(17))
+pal_primer <- function(palette = c("mark17"), alpha = 1) {
   palette <- match.arg(palette)
 
   if (alpha > 1L || alpha <= 0L) stop("alpha must be in (0, 1]")
@@ -61,7 +61,7 @@ pal_primer <- function(palette = c("default"), alpha = 1) {
 #' @examples
 #' example_scatterplot() + scale_color_primer()
 #' example_barplot() + scale_fill_primer()
-scale_color_primer <- function(palette = c("default"), alpha = 1, ...) {
+scale_color_primer <- function(palette = c("mark17"), alpha = 1, ...) {
   palette <- match.arg(palette)
   if (is_ggplot2_350()) {
     discrete_scale("colour", palette = pal_primer(palette, alpha), ...)
@@ -77,7 +77,7 @@ scale_colour_primer <- scale_color_primer
 #' @export scale_fill_primer
 #' @importFrom ggplot2 discrete_scale
 #' @rdname scale_primer
-scale_fill_primer <- function(palette = c("default"), alpha = 1, ...) {
+scale_fill_primer <- function(palette = c("mark17"), alpha = 1, ...) {
   palette <- match.arg(palette)
   if (is_ggplot2_350()) {
     discrete_scale("fill", palette = pal_primer(palette, alpha), ...)

--- a/R/palettes.R
+++ b/R/palettes.R
@@ -152,7 +152,7 @@ ggsci_db$"observable"$"observable10" <- c(
 )
 
 # Primer data visualization color palette ----
-ggsci_db$"primer"$"default" <- c(
+ggsci_db$"primer"$"mark17" <- c(
   "Blue" = "#006EDB",
   "Orange" = "#EB670F",
   "Red" = "#DF0C24",

--- a/man/pal_primer.Rd
+++ b/man/pal_primer.Rd
@@ -4,11 +4,11 @@
 \alias{pal_primer}
 \title{Primer design system palette}
 \usage{
-pal_primer(palette = c("default"), alpha = 1)
+pal_primer(palette = c("mark17"), alpha = 1)
 }
 \arguments{
 \item{palette}{Palette type.
-Currently there is one available option: \code{"default"}
+Currently there is one available option: \code{"mark17"}
 (17-color palette).}
 
 \item{alpha}{Transparency level, a real number in (0, 1].
@@ -19,8 +19,8 @@ The Primer design system data visualization palette.
 }
 \examples{
 library("scales")
-show_col(pal_primer("default")(17))
-show_col(pal_primer("default", alpha = 0.6)(17))
+show_col(pal_primer("mark17")(17))
+show_col(pal_primer("mark17", alpha = 0.6)(17))
 }
 \references{
 GitHub (2024). "Primer data visualization colors."

--- a/man/scale_primer.Rd
+++ b/man/scale_primer.Rd
@@ -6,15 +6,15 @@
 \alias{scale_fill_primer}
 \title{Primer color scales}
 \usage{
-scale_color_primer(palette = c("default"), alpha = 1, ...)
+scale_color_primer(palette = c("mark17"), alpha = 1, ...)
 
-scale_colour_primer(palette = c("default"), alpha = 1, ...)
+scale_colour_primer(palette = c("mark17"), alpha = 1, ...)
 
-scale_fill_primer(palette = c("default"), alpha = 1, ...)
+scale_fill_primer(palette = c("mark17"), alpha = 1, ...)
 }
 \arguments{
 \item{palette}{Palette type.
-Currently there is one available option: \code{"default"}
+Currently there is one available option: \code{"mark17"}
 (17-color palette).}
 
 \item{alpha}{Transparency level, a real number in (0, 1].

--- a/vignettes/ggsci.Rmd
+++ b/vignettes/ggsci.Rmd
@@ -87,7 +87,7 @@ summarized in the table below.
 | Observable      | `scale_color_observable()`   | `"observable10"`               | `pal_observable()`   |
 |                 | `scale_fill_observable()`    |                                |                      |
 +-----------------+------------------------------+--------------------------------+----------------------+
-| Primer          | `scale_color_primer()`       | `"default"`                    | `pal_primer()`       |
+| Primer          | `scale_color_primer()`       | `"mark17"`                     | `pal_primer()`       |
 |                 | `scale_fill_primer()`        |                                |                      |
 +-----------------+------------------------------+--------------------------------+----------------------+
 | LocusZoom       | `scale_color_locuszoom()`    | `"default"`                    | `pal_locuszoom()`    |


### PR DESCRIPTION
This PR is a follow-up to #62 by renaming the default palette name of the Primer scale from `"default"` to `"mark17"`.

This makes the palette name more distinguishable (in case of future additions) as these colors appeared under the section "Available **mark** colors" and were described as:

> All chart **marks** (lines, bars, charts, areas, slices) must meet a 3:1 contrast ratio against the background. If an outline is used, either the outline or the fill must meet a 3:1 contrast ratio.
>
> While there aren't specific rules on contrast between chart **mark** colors, it is recommended to use colors of different lightness to make them easier to differentiate.