### PR TITLE
Add link to ggsci-iterm microsite in vignette

### DIFF
--- a/R/discrete-iterm.R
+++ b/R/discrete-iterm.R
@@ -3,6 +3,10 @@
 #' ANSI terminal color palettes sourced from the iterm2-color-schemes project.
 #' Each theme provides normal and bright variants.
 #'
+#' @details
+#' Preview all available iTerm color palettes in ggsci:
+#' <https://nanx.me/ggsci-iterm/>.
+#'
 #' @param palette Palette name. See [iterm_palettes()] for available options.
 #' @param variant Variant of the palette. One of `"normal"`, `"bright"`.
 #' @param alpha Transparency level, a real number in (0, 1].
@@ -40,6 +44,10 @@ pal_iterm <- function(palette = iterm_palettes(), variant = c("normal", "bright"
 #' iTerm color scales
 #'
 #' See [pal_iterm()] for details.
+#'
+#' @details
+#' Preview all available iTerm color palettes in ggsci:
+#' <https://nanx.me/ggsci-iterm/>.
 #'
 #' @inheritParams pal_iterm
 #' @param ... Additional parameters for [ggplot2::discrete_scale()].

--- a/man/pal_iterm.Rd
+++ b/man/pal_iterm.Rd
@@ -22,6 +22,10 @@ See \code{alpha} in \code{\link[grDevices:rgb]{grDevices::rgb()}} for details.}
 ANSI terminal color palettes sourced from the iterm2-color-schemes project.
 Each theme provides normal and bright variants.
 }
+\details{
+Preview all available iTerm color palettes in ggsci:
+\url{https://nanx.me/ggsci-iterm/}.
+}
 \examples{
 library("scales")
 show_col(pal_iterm("Rose Pine")(6))

--- a/man/scale_iterm.Rd
+++ b/man/scale_iterm.Rd
@@ -40,6 +40,10 @@ See \code{alpha} in \code{\link[grDevices:rgb]{grDevices::rgb()}} for details.}
 \description{
 See \code{\link[=pal_iterm]{pal_iterm()}} for details.
 }
+\details{
+Preview all available iTerm color palettes in ggsci:
+\url{https://nanx.me/ggsci-iterm/}.
+}
 \examples{
 example_scatterplot() + scale_color_iterm("Rose Pine")
 example_barplot() + scale_fill_iterm("Rose Pine")

--- a/vignettes/ggsci.Rmd
+++ b/vignettes/ggsci.Rmd
@@ -325,6 +325,10 @@ which includes 400+ color schemes (list them with `iterm_palettes()`).
 Each scheme provides six categorical colors with two possible variants:
 `"normal"` and `"bright"`.
 
+You can preview these color palettes in ggsci on a dedicated microsite:
+<https://nanx.me/ggsci-iterm/>. It renders example plots for all palettes
+on a single page for fast visual comparison.
+
 ```{r}
 p1_iterm <- p1 + scale_color_iterm("Rose Pine")
 p2_iterm <- p2 + scale_fill_iterm("Rose Pine")


### PR DESCRIPTION
This PR added a link to the new microsite: <https://nanx.me/ggsci-iterm/> in `vignettes/ggsci.Rmd`.

The site helps users to preview **all** iterm color palettes in ggsci.

I did not build a preview within the package documentation or pkgdown site considering the source package size limits (<5MB) and my reluctance to either slow down the site build speed or bloat up the site size.