### PR TITLE
Update BMJ style guide link to GitHub repo

### DIFF
--- a/R/discrete-bmj.R
+++ b/R/discrete-bmj.R
@@ -16,7 +16,7 @@
 #' @author Hui Chen | \email{huichen@zju.edu.cn}
 #'
 #' @references
-#' <https://technology.bmj.com/living-style-guide/colour.html>
+#' <https://github.com/BMJ-Ltd/living-style-guide>
 #'
 #' @examples
 #' library("scales")
@@ -54,7 +54,7 @@ pal_bmj <- function(palette = c("default"), alpha = 1) {
 #' @rdname scale_bmj
 #'
 #' @references
-#' <https://technology.bmj.com/living-style-guide/colour.html>
+#' <https://github.com/BMJ-Ltd/living-style-guide>
 #'
 #' @examples
 #' example_scatterplot() + scale_color_bmj()

--- a/man/pal_bmj.Rd
+++ b/man/pal_bmj.Rd
@@ -23,7 +23,7 @@ show_col(pal_bmj("default")(9))
 show_col(pal_bmj("default", alpha = 0.6)(9))
 }
 \references{
-\url{https://technology.bmj.com/living-style-guide/colour.html}
+\url{https://github.com/BMJ-Ltd/living-style-guide}
 }
 \author{
 Hui Chen | \email{huichen@zju.edu.cn}

--- a/man/scale_bmj.Rd
+++ b/man/scale_bmj.Rd
@@ -30,7 +30,7 @@ example_scatterplot() + scale_color_bmj()
 example_barplot() + scale_fill_bmj()
 }
 \references{
-\url{https://technology.bmj.com/living-style-guide/colour.html}
+\url{https://github.com/BMJ-Ltd/living-style-guide}
 }
 \author{
 Hui Chen | \email{huichen@zju.edu.cn}

--- a/vignettes/ggsci.Rmd
+++ b/vignettes/ggsci.Rmd
@@ -243,7 +243,7 @@ grid.arrange(p1_jama, p2_jama, ncol = 2)
 ### BMJ
 
 The BMJ palette is from the
-[BMJ living style guide](https://technology.bmj.com/living-style-guide/colour.html):
+[BMJ living style guide](https://github.com/BMJ-Ltd/living-style-guide):
 
 ```{r}
 p1_bmj <- p1 + scale_color_bmj()


### PR DESCRIPTION
This PR replaces the BMJ style guide link to its GitHub repo link, as the old link now shows a 404 page and triggers an `R CMD check` warning.