### PR TITLE
Fix GenePattern HeatMapImage link

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,5 +35,5 @@ Suggests:
     rmarkdown
 VignetteBuilder: knitr
 Encoding: UTF-8
-RoxygenNote: 7.3.3
 Roxygen: list(markdown = TRUE)
+Config/roxygen2/version: 8.0.0

--- a/R/continuous-gsea.R
+++ b/R/continuous-gsea.R
@@ -19,7 +19,7 @@
 #' @author Nan Xiao | \email{me@nanx.me} | <https://nanx.me>
 #'
 #' @note The 12 base colors used in this palette are derived from the
-#' [HeatMapImage documentation](https://modulerepository.genepattern.org/gpModuleRepository/download/prod/module/?file=/HeatMapImage/broad.mit.edu:cancer.software.genepattern.module.analysis/00032/6/HeatMapImage.pdf).
+#' [HeatMapImage documentation](https://github.com/genepattern/GenePatternModuleCatalog/blob/main/modules/HeatMapImage/broad.mit.edu%3Acancer.software.genepattern.module.analysis/00032/6/HeatMapImage.zip).
 #'
 #' @examples
 #' library("scales")

--- a/man/ggsci-package.Rd
+++ b/man/ggsci-package.Rd
@@ -22,6 +22,11 @@ Useful links:
 \author{
 \strong{Maintainer}: Nan Xiao \email{me@nanx.me} (\href{https://orcid.org/0000-0002-0250-5673}{ORCID}) [copyright holder]
 
+Authors:
+\itemize{
+  \item Nan Xiao \email{me@nanx.me} (\href{https://orcid.org/0000-0002-0250-5673}{ORCID}) [copyright holder]
+}
+
 Other contributors:
 \itemize{
   \item Joshua Cook \email{joshuacook0023@gmail.com} [contributor]

--- a/man/pal_gephi.Rd
+++ b/man/pal_gephi.Rd
@@ -19,7 +19,7 @@ arbitrary number of categories.
 }
 \details{
 The Gephi palette generator uses the current R random number state directly.
-If you need reproducible results, call \code{\link[base:Random]{base::set.seed()}} before creating
+If you need reproducible results, call \code{\link[base:set.seed]{base::set.seed()}} before creating
 a palette or evaluating the scale. To isolate RNG side effects, consider
 using \code{withr::with_seed()}.
 }

--- a/man/rgb_gsea.Rd
+++ b/man/rgb_gsea.Rd
@@ -24,7 +24,7 @@ heatmaps plotted by GSEA GenePattern.
 }
 \note{
 The 12 base colors used in this palette are derived from the
-\href{https://modulerepository.genepattern.org/gpModuleRepository/download/prod/module/?file=/HeatMapImage/broad.mit.edu:cancer.software.genepattern.module.analysis/00032/6/HeatMapImage.pdf}{HeatMapImage documentation}.
+\href{https://github.com/genepattern/GenePatternModuleCatalog/blob/main/modules/HeatMapImage/broad.mit.edu\%3Acancer.software.genepattern.module.analysis/00032/6/HeatMapImage.zip}{HeatMapImage documentation}.
 }
 \examples{
 library("scales")


### PR DESCRIPTION
This PR updates the GenePattern HeatMapImage documentation link (file moved from self-hosted website to GitHub repo) so that `urlchecker::url_check()` is happy.